### PR TITLE
feat: replace table in "Related PRs" with bullet points (VF-000)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,10 +23,7 @@
 
 <!-- List related PRs against other branches -->
 
-| branch              | PR          |
-| ------------------- | ----------- |
-| other_pr_production | [link](url) |
-| other_pr_master     | [link](url) |
+- https://github.com/voiceflow/XXXXXXXXX/pull/123
 
 ### Checklist
 


### PR DESCRIPTION
**Fixes or implements VF-000**

### Brief description. What is this change?

i've noticed some of the new team members actually using the table in the "Related PRs" section which seems like an annoying process and i'm not sure if anyone benefits from the table. github added special rendering for bullet point lists of PR links so i'd recommend using that instead

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
